### PR TITLE
simplify reshape with torch.flatten

### DIFF
--- a/repvgg.py
+++ b/repvgg.py
@@ -181,7 +181,7 @@ class RepVGG(nn.Module):
         out = self.stage3(out)
         out = self.stage4(out)
         out = self.gap(out)
-        out = out.view(out.size(0), -1)
+        out = torch.flatten(out, 1)
         out = self.linear(out)
         return out
 


### PR DESCRIPTION
The change will make the onnx more concise.

before: 
![image](https://user-images.githubusercontent.com/1034542/123586357-2d40c900-d817-11eb-96fd-a210e734beab.png )

after: 
![image](https://user-images.githubusercontent.com/1034542/123586435-48abd400-d817-11eb-852f-c5f4885da1d8.png )

